### PR TITLE
Build RPM and publish them

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        set -x
+        make -C rpm/
+        assets=()
+        for asset in ./rpm/build/*.rpm; do
+          assets+=("-a" "$asset")
+        done
+        tag_name="${GITHUB_REF##*/}"
+        hub release create "${assets[@]}" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a new tag is pushed, this GH action is triggered.
It is in charge of building the RPM, creating the GH release and
publishing the RPM files as release assets.

The release work flow is:
- make a new GitHub release of dbt2, for example vX.Y
- update the version number in rpm/build.sh to vX.Y
- create a new tag vX.Y with: git tag vX.Y
- push the tag with: git push origin vX.Y