### PR TITLE
Split pgsql stored functions packages

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -18,7 +18,8 @@ yum-builddep -y /workspace/rpm/dbt2-client.spec
 yum-builddep -y /workspace/rpm/dbt2-db.spec
 yum-builddep -y /workspace/rpm/dbt2-driver.spec
 yum-builddep -y /workspace/rpm/dbt2-exec.spec
-yum-builddep -y /workspace/rpm/dbt2-pgsql.spec
+yum-builddep -y /workspace/rpm/dbt2-pgsql-c.spec
+yum-builddep -y /workspace/rpm/dbt2-pgsql-plpgsql.spec
 yum-builddep -y /workspace/rpm/dbt2-scripts.spec
 
 (cd /workspace && curl -OL https://github.com/osdldbt/dbt2/archive/refs/tags/${TAG}.zip)
@@ -30,8 +31,16 @@ for PGVERSION in 11 12 13 14; do
 		--define "pkgversion ${VERSION}" \
 		--define "_topdir ${PWD}/tmp/rpm" \
 		--define "_sourcedir ${PWD}/workspace" \
-		-bb /workspace/rpm/dbt2-pgsql.spec
+		-bb /workspace/rpm/dbt2-pgsql-c.spec
 done;
+
+# PostgreSQL PL/pgsql stored functions
+rpmbuild \
+	--clean \
+	--define "pkgversion ${VERSION}" \
+	--define "_topdir ${PWD}/tmp/rpm" \
+	--define "_sourcedir ${PWD}/workspace" \
+	-bb /workspace/rpm/dbt2-pgsql-plpgsql.spec
 
 # Binary for the client
 rpmbuild \

--- a/rpm/dbt2-pgsql-c.spec
+++ b/rpm/dbt2-pgsql-c.spec
@@ -3,13 +3,13 @@
 %{!?pgversion: %global pgversion 14}
 %define installpath /usr/bin
 %define pgpath /usr/pgsql-%{pgversion}
-%global pkgname dbt2-pgsql_%{pgversion}
+%global pkgname dbt2-pgsql-c_%{pgversion}
 %define _unpackaged_files_terminate_build 0
 
 Name:          %{pkgname}
 Version:       %{pkgversion}
 Release:       %{pkgrevision}%{?dist}
-Summary:       Fair Use TPC-C benchmark kit - PostgreSQL Stored Functions
+Summary:       Fair Use TPC-C benchmark kit - PostgreSQL C Stored Functions
 License:       The Artistic License
 Source:        v%{version}.zip
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
@@ -17,7 +17,7 @@ Requires:      postgresql%{pgversion}-server, llvm-libs, postgresql%{pgversion}
 
 
 %description
-TPC-C benchmark kit - PostgreSQL extension and scripts
+Fair Use TPC-C benchmark kit - PostgreSQL C Stored Functions
 
 %prep
 %setup -q -n dbt2-%{version}
@@ -25,21 +25,9 @@ TPC-C benchmark kit - PostgreSQL extension and scripts
 %install
 %{__install} -d %{buildroot}/%{installpath}
 %{__install} -d %{buildroot}/%{pgpath}/share
-%{__install} -c -m 644 storedproc/pgsql/pgsql/delivery.sql  %{buildroot}/%{pgpath}/share/.
-%{__install} -c -m 644 storedproc/pgsql/pgsql/new_order.sql  %{buildroot}/%{pgpath}/share/.
-%{__install} -c -m 644 storedproc/pgsql/pgsql/order_status.sql  %{buildroot}/%{pgpath}/share/.
-%{__install} -c -m 644 storedproc/pgsql/pgsql/payment.sql  %{buildroot}/%{pgpath}/share/.
-%{__install} -c -m 644 storedproc/pgsql/pgsql/stock_level.sql  %{buildroot}/%{pgpath}/share/.
 PATH=$PATH:%{pgpath}/bin make -C storedproc/pgsql/c/ install DESTDIR=%{buildroot}
 
 %files
-# pl/pgsql stored functions
-%{pgpath}/share/delivery.sql
-%{pgpath}/share/new_order.sql
-%{pgpath}/share/order_status.sql
-%{pgpath}/share/payment.sql
-%{pgpath}/share/stock_level.sql
-# PostgreSQL extension
 %{pgpath}/lib/dbt2.so
 %{pgpath}/lib/bitcode/dbt2
 %{pgpath}/lib/bitcode/dbt2.index.bc

--- a/rpm/dbt2-pgsql-plpgsql.spec
+++ b/rpm/dbt2-pgsql-plpgsql.spec
@@ -1,8 +1,7 @@
 %global debug_package %{nil}
 %{!?pkgrevision: %global pkgrevision 1}
-%{!?pgversion: %global pgversion 14}
-%define installpath /usr/share
-%global pkgname dbt2-pgsql-plpgsql_%{pgversion}
+%define installpath /usr/share/dbt2
+%global pkgname dbt2-pgsql-plpgsql
 %define _unpackaged_files_terminate_build 0
 
 Name:          %{pkgname}
@@ -12,7 +11,6 @@ Summary:       Fair Use TPC-C benchmark kit - PostgreSQL PL/pgsql Stored Functio
 License:       The Artistic License
 Source:        v%{version}.zip
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-Requires:      postgresql%{pgversion}-server, llvm-libs, postgresql%{pgversion}
 
 
 %description

--- a/rpm/dbt2-pgsql-plpgsql.spec
+++ b/rpm/dbt2-pgsql-plpgsql.spec
@@ -1,0 +1,41 @@
+%global debug_package %{nil}
+%{!?pkgrevision: %global pkgrevision 1}
+%{!?pgversion: %global pgversion 14}
+%define installpath /usr/share
+%global pkgname dbt2-pgsql-plpgsql_%{pgversion}
+%define _unpackaged_files_terminate_build 0
+
+Name:          %{pkgname}
+Version:       %{pkgversion}
+Release:       %{pkgrevision}%{?dist}
+Summary:       Fair Use TPC-C benchmark kit - PostgreSQL PL/pgsql Stored Functions
+License:       The Artistic License
+Source:        v%{version}.zip
+BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Requires:      postgresql%{pgversion}-server, llvm-libs, postgresql%{pgversion}
+
+
+%description
+Fair Use TPC-C benchmark kit - PostgreSQL PL/pgsql Stored Functions
+
+%prep
+%setup -q -n dbt2-%{version}
+
+%install
+mkdir -p %{buildroot}/%{installpath}
+cp -p storedproc/pgsql/pgsql/delivery.sql %{buildroot}/%{installpath}/
+cp -p storedproc/pgsql/pgsql/new_order.sql %{buildroot}/%{installpath}/
+cp -p storedproc/pgsql/pgsql/order_status.sql %{buildroot}/%{installpath}/
+cp -p storedproc/pgsql/pgsql/payment.sql %{buildroot}/%{installpath}/
+cp -p storedproc/pgsql/pgsql/stock_level.sql %{buildroot}/%{installpath}/
+
+%files
+%{installpath}/delivery.sql
+%{installpath}/new_order.sql
+%{installpath}/order_status.sql
+%{installpath}/payment.sql
+%{installpath}/stock_level.sql
+
+%changelog
+* Fri Oct 15 2021 Julien Tachoires <julmon@gmail.com> - master-1
+- Initial packaging


### PR DESCRIPTION
The pl/pgsql stored functions don't have to be installed with the C
stored functions, and furthermore are PostgreSQL version agnostic.