### PR TITLE
Patch scripts rpm for pgsql-load-stored-procs

### DIFF
--- a/rpm/build.sh
+++ b/rpm/build.sh
@@ -14,6 +14,8 @@ dnf install -y postgresql12-server postgresql12-devel postgresql12-libs
 dnf install -y postgresql11-server postgresql11-devel postgresql11-libs
 dnf install cmake gcc make postgresql-devel postgresql-libs  -y
 
+cp /workspace/rpm/*.patch /workspace/
+
 yum-builddep -y /workspace/rpm/dbt2-client.spec
 yum-builddep -y /workspace/rpm/dbt2-db.spec
 yum-builddep -y /workspace/rpm/dbt2-driver.spec

--- a/rpm/dbt2-pgsql-load-stored-procs.patch
+++ b/rpm/dbt2-pgsql-load-stored-procs.patch
@@ -1,0 +1,13 @@
+diff --git a/src/scripts/pgsql/dbt2-pgsql-load-stored-procs b/src/scripts/pgsql/dbt2-pgsql-load-stored-procs
+index 55d6f24..e7f8023 100755
+--- a/src/scripts/pgsql/dbt2-pgsql-load-stored-procs
++++ b/src/scripts/pgsql/dbt2-pgsql-load-stored-procs
+@@ -43,7 +43,7 @@ PSQL="psql -v ON_ERROR_STOP=1 -X ${PORTARG} -e -d ${DBT2DBNAME}"
+ 
+ if [ "${TYPE}" = "plpgsql" ]; then
+ 	echo "loading pl/pgsql stored functions..."
+-	SHAREDIR=`pg_config --sharedir`
++	SHAREDIR="/usr/share/dbt2"
+ 	${PSQL} -f ${SHAREDIR}/delivery.sql || exit 1
+ 	${PSQL} -f ${SHAREDIR}/new_order.sql || exit 1
+ 	${PSQL} -f ${SHAREDIR}/order_status.sql || exit 1

--- a/rpm/dbt2-scripts.spec
+++ b/rpm/dbt2-scripts.spec
@@ -11,15 +11,17 @@ Release:       %{pkgrevision}%{?dist}
 Summary:       Fair Use TPC-C benchmark kit - Scripts
 License:       The Artistic License
 Source:        v%{version}.zip
+Patch0:        dbt2-pgsql-load-stored-procs.patch
 BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Requires:      coreutils, procps-ng, sysstat
 
 
 %description
-TPC-C benchmark kit
+Fair Use TPC-C benchmark kit - Scripts
 
 %prep
 %setup -q -n dbt2-%{version}
+%patch0 -p1
 
 %build
 PATH=$PATH:/usr/pgsql-%{pgversion}/bin cmake -DCMAKE_INSTALL_PREFIX=%{buildroot}/%{installpath}/.. -DDBMS=pgsql


### PR DESCRIPTION
Hard code the location of the pl/pgsql stored functions.  It makes more
sense to patch pgsql-load-stored-procs for the RPM than it does to
modify it upstream.
